### PR TITLE
pom.xml updated for offsite work

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -134,5 +134,6 @@
             </plugin>
         </plugins>
     </reporting>
+
 </project>
 


### PR DESCRIPTION
Dropped the `bar` repository (should go into `~/.m2/settings.xml` as a proxy definition); reverted to `com.sencha.gxt:gxt:3.0.0-beta1` as the latest publicly available
