### PR TITLE
SQL Wait timeout bug fix.

### DIFF
--- a/app/integration/ae-integration/src/main/java/uk/ac/ebi/fg/annotare2/integration/AeIntegrationWatchdog.java
+++ b/app/integration/ae-integration/src/main/java/uk/ac/ebi/fg/annotare2/integration/AeIntegrationWatchdog.java
@@ -88,6 +88,7 @@ public class AeIntegrationWatchdog {
     private final Messenger messenger;
     private ScheduledExecutorService scheduler;
     private BlockingQueue<Long> submissionsBeingProcessed;
+    private final SubmissionStatusUpdater submissionStatusUpdater;
 
     private enum SubmissionOutcome {
         INITIAL_SUBMISSION_OK,
@@ -107,7 +108,8 @@ public class AeIntegrationWatchdog {
                                  DataFileManager dataFileManager,
                                  FileValidationService fileValidationService, FtpManager ftpManager,
                                  EfoSearch efoSearch,
-                                 Messenger messenger) {
+                                 Messenger messenger,
+                                 SubmissionStatusUpdater submissionStatusUpdater) {
         this.sessionFactory = sessionFactory;
         this.subsTracking = subsTracking;
         this.aeConnection = aeConnection;
@@ -122,6 +124,7 @@ public class AeIntegrationWatchdog {
         this.messenger = messenger;
         this.scheduler = Executors.newScheduledThreadPool(properties.getWatchdogThreadCount());
         this.submissionsBeingProcessed = new ArrayBlockingQueue<>(properties.getWatchdogThreadCount());
+        this.submissionStatusUpdater = submissionStatusUpdater;
     }
 
     @PostConstruct
@@ -327,8 +330,7 @@ public class AeIntegrationWatchdog {
             MINUTES.sleep(479); // artificial delay to check for SQL expeception
             logger.debug("Thread has woken up again. Hello World!");
 
-            submission.setStatus(SubmissionStatus.IN_CURATION);
-            submissionManager.save(submission);
+            submissionStatusUpdater.add(submission);
 
             if (properties.isSubsTrackingEnabled()) {
                 String otrsTemplate = (SubmissionOutcome.INITIAL_SUBMISSION_OK == outcome) ?

--- a/app/integration/ae-integration/src/main/java/uk/ac/ebi/fg/annotare2/integration/ArrayExpressIntegrationPlugin.java
+++ b/app/integration/ae-integration/src/main/java/uk/ac/ebi/fg/annotare2/integration/ArrayExpressIntegrationPlugin.java
@@ -42,7 +42,7 @@ public class ArrayExpressIntegrationPlugin extends AbstractModule {
         bind(AEConnection.class).in(SINGLETON);
         bind(AeIntegrationWatchdog.class).asEagerSingleton();
         bind(FileValidationService.class).asEagerSingleton();
-
+        bind(SubmissionStatusUpdater.class).asEagerSingleton();
         bind(MessengerService.class).to(RtMessengerService.class).asEagerSingleton();
 
         bind(ExtendedAnnotareProperties.class).asEagerSingleton();

--- a/app/integration/ae-integration/src/main/java/uk/ac/ebi/fg/annotare2/integration/SubmissionStatusUpdater.java
+++ b/app/integration/ae-integration/src/main/java/uk/ac/ebi/fg/annotare2/integration/SubmissionStatusUpdater.java
@@ -1,0 +1,64 @@
+package uk.ac.ebi.fg.annotare2.integration;
+
+import com.google.inject.Inject;
+import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.ebi.fg.annotare2.core.components.SubmissionManager;
+import uk.ac.ebi.fg.annotare2.db.model.Submission;
+import uk.ac.ebi.fg.annotare2.db.model.enums.SubmissionStatus;
+import uk.ac.ebi.fg.annotare2.db.util.HibernateSessionFactory;
+
+import javax.annotation.PostConstruct;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class SubmissionStatusUpdater {
+    private static final Logger logger = LoggerFactory.getLogger(SubmissionStatusUpdater.class);
+
+    private final BlockingQueue<Submission> submissionsQueue;
+    private final SubmissionManager submissionManager;
+    private final ScheduledExecutorService scheduler;
+    private final HibernateSessionFactory sessionFactory;
+
+    @Inject
+    public SubmissionStatusUpdater(SubmissionManager submissionManager,
+                                   HibernateSessionFactory sessionFactory){
+        this.submissionManager = submissionManager;
+        this.sessionFactory = sessionFactory;
+        submissionsQueue = new LinkedBlockingQueue<>();
+        this.scheduler = Executors.newScheduledThreadPool(1);
+    }
+
+    @PostConstruct
+    public void init(){
+        final Runnable updateStatus = new Runnable() {
+            @Override
+            public void run() {
+                if(!submissionsQueue.isEmpty()){
+                    Session session = sessionFactory.openSession();
+                    try {
+                        Submission submission = submissionsQueue.take();
+                        submission.setStatus(SubmissionStatus.IN_CURATION);
+                        submissionManager.save(submission);
+                        logger.debug("Submission: {} status updated to IN_CURATION", submission.getId());
+                    } catch (InterruptedException e) {
+                        logger.error("Error while updating submission status", e);
+                    } finally {
+                        session.close();
+                    }
+                }
+            }
+        };
+
+        scheduler.scheduleAtFixedRate(updateStatus,1000, 1000, TimeUnit.MILLISECONDS);
+    }
+
+    public synchronized void add(Submission submission){
+        submissionsQueue.add(submission);
+    }
+
+}


### PR DESCRIPTION
Instead of updating submission status immediately after file upload completes, I have added that submission into a in-memory queue. A separate thread polls into the queue and change the status of the submission to IN_CURATION. I think in this way the status update happens in a separate session rather than waiting for file upload completes.