### PR TITLE
Limpopo-2.0.0 upgrade.

### DIFF
--- a/app/core/src/main/java/uk/ac/ebi/fg/annotare2/core/magetab/MageTabFiles.java
+++ b/app/core/src/main/java/uk/ac/ebi/fg/annotare2/core/magetab/MageTabFiles.java
@@ -91,7 +91,7 @@ public class MageTabFiles {
             SDRFWriter sdrfWriter = null;
             try {
                 sdrfWriter = new SDRFWriter(new FileWriter(sdrfFile));
-                sdrfWriter.write(generated.SDRFs.values().iterator().next());
+                sdrfWriter.write(generated.SDRFs.values().iterator().next(), false, true);
             } finally {
                 close(sdrfWriter, true);
             }

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -46,8 +46,8 @@
   </scm>
 
     <properties>
-        <java.version>1.7</java.version>
-        <limpopo.version>1.2.0</limpopo.version>
+        <java.version>1.8</java.version>
+        <limpopo.version>2.0.0</limpopo.version>
         <magetabcheck.version>1.27</magetabcheck.version>
         <resumable-gwt.version>1.0.2</resumable-gwt.version>
         <gwt.version>2.7.0</gwt.version>


### PR DESCRIPTION
Upgraded java version to 1.8 as Limpopo-2.0.0 built on java-1.8.
Used faster version of SDRF writer method.