### PR TITLE
Add 5 new experiment types

### DIFF
--- a/app/webapp/src/main/resources/ArrayExpressExperimentTypes.txt
+++ b/app/webapp/src/main/resources/ArrayExpressExperimentTypes.txt
@@ -9,7 +9,9 @@ ChIP-chip by tiling array
 ChIP-seq
 CLIP-seq
 comparative genomic hybridization by array
+CUT&RUN
 DNA-seq
+exome sequencing
 FAIRE-seq
 genotyping by array
 genotyping by high throughput sequencing
@@ -32,6 +34,8 @@ RNA-seq of coding RNA from single cells
 RNA-seq of non coding RNA
 RNA-seq of non coding RNA from single cells
 RNA-seq of total RNA
+scATAC-seq
+spatial transcriptomics by high-throughput sequencing
 tiling path by array
 transcription profiling by array
 transcription profiling by RT-PCR

--- a/app/webapp/src/main/resources/ArrayExpressExperimentTypes.txt
+++ b/app/webapp/src/main/resources/ArrayExpressExperimentTypes.txt
@@ -35,6 +35,7 @@ RNA-seq of non coding RNA
 RNA-seq of non coding RNA from single cells
 RNA-seq of total RNA
 scATAC-seq
+single nucleus RNA sequencing
 spatial transcriptomics by high-throughput sequencing
 tiling path by array
 transcription profiling by array

--- a/app/webapp/src/main/webapp/assets/pages/help/experiment_types.html
+++ b/app/webapp/src/main/webapp/assets/pages/help/experiment_types.html
@@ -76,9 +76,19 @@
           <td><a href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-2293/">E-MTAB-2293</a></td>
       </tr>
       <tr>
+          <td>CUT&RUN</td>
+          <td><a href="https://www.ebi.ac.uk/efo/EFO_0009973">EFO_0009973</a></td>
+          <td><a href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-9897/">E-MTAB-9897</a></td>
+      </tr>
+      <tr>
           <td>DNA-seq</td>
           <td><a href="https://www.ebi.ac.uk/efo/EFO_0002693">EFO_0002693</a></td>
           <td><a href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-3109/">E-MTAB-3109</a></td>
+      </tr>
+      <tr>
+          <td>exome sequencing</td>
+          <td><a href="https://www.ebi.ac.uk/efo/EFO_0005396">EFO_0005396</a></td>
+          <td><a href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-9936/">E-MTAB-9936</a></td>
       </tr>
       <tr>
           <td>FAIRE-seq</td><td><a href="https://www.ebi.ac.uk/efo/EFO_0004428">EFO_0004428</a></td>
@@ -182,6 +192,16 @@
           <td>RNA-seq of total RNA</td>
           <td><a href="https://www.ebi.ac.uk/efo/EFO_0009653">EFO_0009653</a></td>
           <td><a href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-8118">E-MTAB-8118</a></td>
+      </tr>
+      <tr>
+          <td>scATAC-seq</td>
+          <td><a href="https://www.ebi.ac.uk/efo/EFO_0010891">EFO_0010891</a></td>
+          <td><a href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-10382">E-MTAB-10382</a></td>
+      </tr>
+      <tr>
+          <td>spatial transcriptomics by high-throughput sequencing</td>
+          <td><a href="https://www.ebi.ac.uk/efo/EFO_0030005">EFO_0030005</a></td>
+          <td><a href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-10386">E-MTAB-10386</a></td>
       </tr>
       <tr>
           <td>tiling path by array</td>

--- a/app/webapp/src/main/webapp/assets/pages/help/experiment_types.html
+++ b/app/webapp/src/main/webapp/assets/pages/help/experiment_types.html
@@ -199,6 +199,11 @@
           <td><a href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-10382">E-MTAB-10382</a></td>
       </tr>
       <tr>
+          <td>single nucleus RNA sequencing</td>
+          <td><a href="http://www.ebi.ac.uk/efo/EFO_0009809">EFO_0009809</a></td>
+          <td><a href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-8562">E-MTAB-8562</a></td>
+      </tr>
+      <tr>
           <td>spatial transcriptomics by high-throughput sequencing</td>
           <td><a href="https://www.ebi.ac.uk/efo/EFO_0030005">EFO_0030005</a></td>
           <td><a href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-10386">E-MTAB-10386</a></td>


### PR DESCRIPTION
This adds four new AE experiment types to the selection list that we can now process: 

    - spatial transcriptomics by high-throughput sequencing
    - scATAC-seq
    - CUT&RUN
    - exome sequencing
    - single nucleus RNA sequencing