### PR TITLE
Editing date of public release option enabled only when user owns submission

### DIFF
--- a/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/common/client/SubmissionService.java
+++ b/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/common/client/SubmissionService.java
@@ -74,4 +74,6 @@ public interface SubmissionService extends RemoteService {
     /*int getSubmissionCountForCurrentUser();*/
 
     boolean checkRtServerStatus(int submissionId) throws Exception;
+
+    boolean isUpdateAllowed(int submissionId) throws ResourceNotFoundException, NoPermissionException;
 }

--- a/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/common/client/SubmissionServiceAsync.java
+++ b/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/common/client/SubmissionServiceAsync.java
@@ -51,4 +51,6 @@ public interface SubmissionServiceAsync {
     /*void getSubmissionCountForCurrentUser(AsyncCallback<Integer> async);*/
 
     void checkRtServerStatus(int submissionId, AsyncCallback<Boolean> async);
+
+    void isUpdateAllowed(int submissionId, AsyncCallback<Boolean> async);
 }

--- a/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/common/client/rpc/ReportingAsyncCallback.java
+++ b/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/common/client/rpc/ReportingAsyncCallback.java
@@ -70,7 +70,8 @@ public abstract class ReportingAsyncCallback<T> implements AsyncCallback<T> {
         UNABLE_TO_LOAD_UPDATES("Unable to load updates"),
         UNABLE_TO_LOAD_USER_INFORMATION("Unable to load user information"),
         UNABLE_TO_SEND_UPDATES("Unable to send updates"),
-        UNABLE_TO_UPLOAD_FILES("Unable to upload files");
+        UNABLE_TO_UPLOAD_FILES("Unable to upload files"),
+        UNABLE_TO_CHECK_SUBMISSION_UPDATE_PERMISSION("Unable to check submission update permission");
 
 
         private final String message;

--- a/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/editor/client/activity/experiment/ExperimentDetailsActivity.java
+++ b/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/editor/client/activity/experiment/ExperimentDetailsActivity.java
@@ -94,6 +94,16 @@ public class ExperimentDetailsActivity extends AbstractActivity implements Exper
     }
 
     private void loadAsync() {
+        experimentDataProxy.isUpdateAllowedAsync(
+                new ReportingAsyncCallback<Boolean>(FailureMessage.UNABLE_TO_CHECK_SUBMISSION_UPDATE_PERMISSION) {
+                    @Override
+                    public void onSuccess(Boolean result) {
+                        System.out.println("ExperimentDetailsActivity.loadAsync.onSuccess");
+                        System.out.println("result = " + result);
+                        view.setUpdateAllowed(result);
+                    }
+                }
+        );
         experimentDataProxy.getExperimentProfileTypeAsync(
                 new ReportingAsyncCallback<ExperimentProfileType>(FailureMessage.UNABLE_TO_LOAD_SUBMISSION_TYPE) {
                     @Override

--- a/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/editor/client/proxy/ExperimentDataProxy.java
+++ b/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/editor/client/proxy/ExperimentDataProxy.java
@@ -19,13 +19,62 @@ package uk.ac.ebi.fg.annotare2.web.gwt.editor.client.proxy;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import uk.ac.ebi.fg.annotare2.submission.model.*;
+import uk.ac.ebi.fg.annotare2.submission.model.Contact;
+import uk.ac.ebi.fg.annotare2.submission.model.ExperimentProfile;
+import uk.ac.ebi.fg.annotare2.submission.model.ExperimentProfileType;
+import uk.ac.ebi.fg.annotare2.submission.model.Extract;
+import uk.ac.ebi.fg.annotare2.submission.model.FileColumn;
+import uk.ac.ebi.fg.annotare2.submission.model.FileRef;
+import uk.ac.ebi.fg.annotare2.submission.model.FileType;
+import uk.ac.ebi.fg.annotare2.submission.model.LabeledExtract;
+import uk.ac.ebi.fg.annotare2.submission.model.Protocol;
+import uk.ac.ebi.fg.annotare2.submission.model.Publication;
+import uk.ac.ebi.fg.annotare2.submission.model.Sample;
+import uk.ac.ebi.fg.annotare2.submission.model.SampleAttribute;
 import uk.ac.ebi.fg.annotare2.web.gwt.common.client.SubmissionServiceAsync;
 import uk.ac.ebi.fg.annotare2.web.gwt.common.client.rpc.AsyncCallbackWrapper;
 import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.ExperimentSettings;
-import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.*;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.ContactDto;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.DataAssignmentColumn;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.DataAssignmentColumnsAndRows;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.DataAssignmentRow;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.ExperimentDetailsDto;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.ExtractAttributesRow;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.LabeledExtracts;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.LabeledExtractsRow;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.ProtocolAssignmentProfile;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.ProtocolAssignmentProfileUpdates;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.ProtocolRow;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.ProtocolType;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.PublicationDto;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.SampleRow;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.SampleRowsAndColumns;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.SingleCellExtractAttributesRow;
 import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.exepriment.columns.SampleColumn;
-import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.*;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.CreateContactCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.CreateDataAssignmentColumnCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.CreateProtocolCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.CreatePublicationCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.CreateSamplesCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.ExperimentUpdateCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.MoveProtocolCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.RemoveContactsCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.RemoveDataAssignmentColumnsCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.RemoveProtocolsCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.RemovePublicationsCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.RemoveSamplesCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateContactCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateDataAssignmentColumnCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateExperimentDetailsCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateExperimentSettingsCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateExtractAttributesRowCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateExtractLabelsRowCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateProtocolAssignmentsCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateProtocolCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdatePublicationCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateSampleColumnsCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateSampleRowCommand;
+import uk.ac.ebi.fg.annotare2.web.gwt.common.shared.update.UpdateSingleCellExtractAttributesRowCommand;
 import uk.ac.ebi.fg.annotare2.web.gwt.editor.client.event.ExperimentUpdateEvent;
 
 import java.util.ArrayList;
@@ -538,5 +587,19 @@ public class ExperimentDataProxy {
 
     public void updateExperimentSettings(ExperimentSettings settings) {
         updateQueue.add(new UpdateExperimentSettingsCommand(settings));
+    }
+
+    public void isUpdateAllowedAsync(AsyncCallback<Boolean> reportingAsyncCallback) {
+        submissionService.isUpdateAllowed(getSubmissionId(), new AsyncCallbackWrapper<Boolean>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                reportingAsyncCallback.onFailure(caught);
+            }
+
+            @Override
+            public void onSuccess(Boolean result) {
+                reportingAsyncCallback.onSuccess(result);
+            }
+        }.wrap());
     }
 }

--- a/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/editor/client/view/experiment/info/ExperimentDetailsView.java
+++ b/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/editor/client/view/experiment/info/ExperimentDetailsView.java
@@ -35,6 +35,8 @@ public interface ExperimentDetailsView extends IsWidget {
 
     public void setPresenter(Presenter presenter);
 
+    void setUpdateAllowed(Boolean isUpdateAllowed);
+
     public interface Presenter {
 
         void saveDetails(ExperimentDetailsDto details);

--- a/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/editor/client/view/experiment/info/ExperimentDetailsViewImpl.java
+++ b/app/webapp/src/main/java/uk/ac/ebi/fg/annotare2/web/gwt/editor/client/view/experiment/info/ExperimentDetailsViewImpl.java
@@ -92,6 +92,8 @@ public class ExperimentDetailsViewImpl extends Composite implements ExperimentDe
 
     private Map<String, OntologyTerm> experimentalDesigns;
 
+    private boolean isUpdateAllowed;
+
     @Inject
     public ExperimentDetailsViewImpl() {
         experimentalDesigns = new LinkedHashMap<>();
@@ -147,6 +149,14 @@ public class ExperimentDetailsViewImpl extends Composite implements ExperimentDe
     @Override
     public void setPresenter(Presenter presenter) {
         this.presenter = presenter;
+    }
+
+    @Override
+    public void setUpdateAllowed(Boolean isUpdateAllowed) {
+        this.isUpdateAllowed = isUpdateAllowed;
+        if(!this.isUpdateAllowed) {
+            dateOfPublicRelease.setEnabled(false);
+        }
     }
 
     @Override


### PR DESCRIPTION
Editing date of public release option enabled only when user owns the submission.
Check if current logged user has ACL permission to Update the submission (i.e, owns the submission)
Check if current logged in user has Curator role.
If any one of above condition true, then Date of release date selection box enabled for editing.